### PR TITLE
fix(inscription): validate inscription status to be either `Active` or `Cancelled`

### DIFF
--- a/src/main/java/com/user/platonapi/inscription/InscriptionService.java
+++ b/src/main/java/com/user/platonapi/inscription/InscriptionService.java
@@ -36,6 +36,10 @@ public class InscriptionService {
     }
 
     public SuccessResponse<Inscription> addInscription(InscriptionDTO inscriptionDTO) throws Exception {
+        if (!inscriptionDTO.getStatus().equals("Active") || !inscriptionDTO.getStatus().equals("Cancelled")) {
+            throw new Exception("inscription status is not Active or Cancelled");
+        }
+
         Inscription inscription = new Inscription(
                 inscriptionDTO.getStudent(),
                 inscriptionDTO.getDocument(),


### PR DESCRIPTION
- Added validation in `InscriptionService` to check that the inscription status is either `Active` or `Cancelled`.
- If the status is different, an exception is thrown with the message "inscription status is not Active or Cancelled".