### PR TITLE
fix(inscription): fix status validation logic for `Active` or `Cancelled`

### DIFF
--- a/src/main/java/com/user/platonapi/inscription/InscriptionService.java
+++ b/src/main/java/com/user/platonapi/inscription/InscriptionService.java
@@ -36,7 +36,7 @@ public class InscriptionService {
     }
 
     public SuccessResponse<Inscription> addInscription(InscriptionDTO inscriptionDTO) throws Exception {
-        if (!inscriptionDTO.getStatus().equals("Active") || !inscriptionDTO.getStatus().equals("Cancelled")) {
+        if (!inscriptionDTO.getStatus().equals("Active") && !inscriptionDTO.getStatus().equals("Cancelled")) {
             throw new Exception("inscription status is not Active or Cancelled");
         }
 


### PR DESCRIPTION
- Fixed the validation logic in `InscriptionService` to correctly check if the inscription status is either `Active` or `Cancelled`.
- Updated the condition to use `&&` instead of `||` to ensure both values are checked properly.